### PR TITLE
ShuffleFilterDetectLiveMode

### DIFF
--- a/docs/includes/pairlists.md
+++ b/docs/includes/pairlists.md
@@ -254,10 +254,10 @@ Min price precision for SHITCOIN/BTC is 8 decimals. If its price is 0.00000011 -
 
 #### ShuffleFilter
 
-Shuffles (randomizes) pairs in the pairlist. It can be used for preventing the bot from trading some of the pairs more frequently then others when you want all pairs be treated with the same priority.
+Shuffles (randomizes) pairs in the pairlist. It can be used for preventing the bot from trading some of the pairs more frequently then others when you want all pairs be treated with the same priority. 
 
 !!! Tip
-    You may set the `seed` value for this Pairlist to obtain reproducible results, which can be useful for repeated backtesting sessions. If `seed` is not set, the pairs are shuffled in the non-repeatable random order.
+    You may set the `seed` value for this Pairlist to obtain reproducible results, which can be useful for repeated backtesting sessions. If `seed` is not set, the pairs are shuffled in the non-repeatable random order. ShuffleFilter will automatically detect runmodes and apply the `seed` only for backtesting modes - if a `seed` value is set.
 
 #### SpreadFilter
 

--- a/freqtrade/plugins/pairlist/ShuffleFilter.py
+++ b/freqtrade/plugins/pairlist/ShuffleFilter.py
@@ -18,7 +18,15 @@ class ShuffleFilter(IPairList):
                  pairlist_pos: int) -> None:
         super().__init__(exchange, pairlistmanager, config, pairlistconfig, pairlist_pos)
 
-        self._seed = pairlistconfig.get('seed')
+        # Apply seed in backtesting mode to get comparable results,
+        # but not in live modes to get a non-repeating order of pairs during live modes.
+        if config['runmode'].value in ('live', 'dry_run'):
+            self._seed = None
+            logger.info("live mode detected, not applying seed.")
+        else:
+            self._seed = pairlistconfig.get('seed')
+            logger.info("Backtesting mode detected, applying seed value: " + str(self._seed))
+
         self._random = random.Random(self._seed)
 
     @property


### PR DESCRIPTION
ShuffleFilter should distinguish between runmodes and do the following: 
Apply seed in backtesting mode to get comparable results, but not in live modes to get a non-repeating order of pairs during live modes.

